### PR TITLE
Make Pod a pure marker trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ members = [".", "./derive_pod"]
 
 [package]
 name = "dataview"
-version = "0.1.2"
+version = "1.0.0"
 authors = ["Casper <CasualX@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"
 
-description = "Safe transmute between types and bit patterns of the same length."
+description = "Safe transmute between types and byte arrays of the same size."
 documentation = "https://docs.rs/dataview/"
 repository = "https://github.com/CasualX/dataview"
 readme = "readme.md"
@@ -21,9 +21,8 @@ features = ["derive_pod"]
 [features]
 default = ["derive_pod"]
 
-# Treat raw pointers as POD
-# This is unsound under Strict Provenance rules
+# Treat raw pointers as POD, this is unsound under Strict Provenance rules
 int2ptr = []
 
 [dependencies]
-derive_pod = { path = "./derive_pod", version = "0.1.1", optional = true }
+derive_pod = { path = "./derive_pod", version = "0.1.2", optional = true }

--- a/derive_pod/Cargo.toml
+++ b/derive_pod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_pod"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Casper <CasualX@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"

--- a/derive_pod/lib.rs
+++ b/derive_pod/lib.rs
@@ -10,9 +10,12 @@ use proc_macro::*;
 ///
 /// The type is checked for requirements of the `Pod` trait:
 ///
-/// * Must be annotated with `repr(C)` or `repr(transparent)`.
+/// * Must be annotated with [`#[repr(C)]`](https://doc.rust-lang.org/nomicon/other-reprs.html#reprc)
+///   or [`#[repr(transparent)]`](https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent).
 /// * Must have every field's type implement `Pod` itself.
 /// * Must not have any padding between its fields, define dummy fields to cover the padding.
+///
+/// Note that it is legal for pod types to be a [ZST](https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts).
 ///
 /// # Compile errors
 ///
@@ -26,18 +29,26 @@ use proc_macro::*;
 ///
 ///   This error means your struct has padding as its size is not equal to a byte array of length equal to the sum of the size of its fields.
 ///
-/// * `error: no rules expected the token <`
+/// * `error: cannot implement Pod for type $TYPE`
 ///
-///   The struct contains generic parameters which are not supported.
-///   It may still be possible to manually implement `Pod` but extra care should be taken to ensure its invariants are upheld.
+///   Deriving `Pod` is not supported for this type.
 ///
-/// * `error: no rules expected the token enum`  
-///   `error: no rules expected the token ;`
-///
-///   Deriving `Pod` implementations for enums, unit structs are not supported.
-///
+///   This includes enums, unions and structs with generics or lifetimes.
 #[proc_macro_derive(Pod)]
 pub fn pod_derive(input: TokenStream) -> TokenStream {
 	let invoke: TokenStream = "::dataview::derive_pod!".parse().unwrap();
+	invoke.into_iter().chain(Some(TokenTree::Group(Group::new(Delimiter::Brace, input)))).collect()
+}
+
+/// Derive macro calculates field offsets.
+///
+/// The type must be a struct and must implement `Pod` or an error is raised.
+///
+/// The derive macro adds an associated constant `FIELD_OFFSETS` to the type.
+/// `FIELD_OFFSETS` is an instance of a struct with `usize` fields for every field in the type.
+/// The value of each field is the offset of that field in the type.
+#[proc_macro_derive(FieldOffsets)]
+pub fn field_offsets(input: TokenStream) -> TokenStream {
+	let invoke: TokenStream = "::dataview::__field_offsets!".parse().unwrap();
 	invoke.into_iter().chain(Some(TokenTree::Group(Group::new(Delimiter::Brace, input)))).collect()
 }

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,9 @@ DataView
 [![docs.rs](https://docs.rs/dataview/badge.svg)](https://docs.rs/dataview)
 [![Build status](https://github.com/CasualX/dataview/workflows/CI/badge.svg)](https://github.com/CasualX/dataview/actions)
 
-The `Pod` trait marks that it is safe to transmute between any bit pattern and an instance of the type.
+The `Pod` trait marks types whose values can be safely transmuted between byte arrays of the same size.
 
-The `DataView` struct provides methods to read and write pod types into the buffer.
+The `DataView` type defines read and write data APIs to an underlying byte buffer.
 
 Library
 -------
@@ -19,32 +19,31 @@ Documentation can be found on [docs.rs](https://docs.rs/dataview/).
 
 In your Cargo.toml, put
 
-```
+```text
 [dependencies]
-dataview = "0.1"
+dataview = "~1.0"
 ```
 
 Examples
 --------
 
 ```rust
-use dataview::Pod;
-
-#[derive(Pod)]
+#[derive(dataview::Pod)]
 #[repr(C)]
 struct MyType {
 	field: i32,
 }
 
-// Construct a zero initialized instance.
-let mut inst = MyType::zeroed();
+// Construct a zero initialized instance
+let mut inst: MyType = dataview::zeroed();
 assert_eq!(inst.field, 0);
 
-// Use the DataView interface to access the instance.
-inst.as_data_view_mut().write(2, &255_u8);
+// Use DataView to access the instance
+let view = dataview::DataView::from_mut(&mut inst);
+view.write(2, &255_u8);
 
-// Returns a byte view over the instance.
-assert_eq!(inst.as_bytes(), &[0, 0, 255, 0]);
+// Create a byte view over the instance
+assert_eq!(dataview::bytes(&inst), &[0, 0, 255, 0]);
 ```
 
 License

--- a/src/data_view.rs
+++ b/src/data_view.rs
@@ -1,40 +1,38 @@
 use core::{mem, ops, ptr, slice};
-use super::Pod;
+use super::*;
 
-/// Read and write data from and to the underlying byte buffer.
-///
-/// Construct the data view through [`Pod::as_data_view`] or [`Pod::as_data_view_mut`].
+/// Read and write data to and from the underlying byte buffer.
 ///
 /// # Operations
 ///
 /// Each set of operations may support a try, panicking and unchecked variations, see below for more information.
 ///
-/// * `copy(offset)`
-///
-///   Copies a (potentially unaligned) value out of the view.
-///
-/// * `copy_into(offset, dest)`
-///
-///    Copies a (potentially unaligned) value out of the view into the dest argument.
-///
 /// * `read(offset)`
 ///
-///   Returns a reference to the data given the offset.
+///   Reads a (potentially unaligned) value out of the view.
+///
+/// * `read_into(offset, dest)`
+///
+///   Reads a (potentially unaligned) value out of the view into the dest argument.
+///
+/// * `get(offset)`
+///
+///   Gets a reference to the data given the offset.
 ///   Errors if the final pointer is misaligned for the given type.
 ///
-/// * `read_mut(offset)`
+/// * `get_mut(offset)`
 ///
-///   Returns a mutable reference to the data given the offset.
+///   Gets a mutable reference to the data given the offset.
 ///   Errors if the final pointer is misaligned for the given type.
 ///
 /// * `slice(offset, len)`
 ///
-///   Returns a slice to the data given the offset and len.
+///   Gets a slice to the data given the offset and len.
 ///   Errors if the final pointer is misaligned for the given type.
 ///
 /// * `slice_mut(offset, len)`
 ///
-///   Returns a mutable slice to the data given the offset.
+///   Gets a mutable slice to the data given the offset.
 ///   Errors if the final pointer is misaligned for the given type.
 ///
 /// * `write(offset, value)`
@@ -55,59 +53,81 @@ use super::Pod;
 /// The *Unchecked* methods have the `_unchecked` suffix and simply assume the offset is correct.
 /// This is *Undefined Behavior* when it results in an out of bounds read or write or if a misaligned reference is produced.
 ///
-/// If the *Try* variation would have returned `None` then the *Unchecked* variation is *Undefined Behavior*.
-pub struct DataView([u8]);
-
-impl AsRef<[u8]> for DataView {
-	#[inline]
-	fn as_ref(&self) -> &[u8] {
-		&self.0
-	}
+/// If the *Try* variation returns `None` then the *Unchecked* variation invokes *Undefined Behavior*.
+#[repr(transparent)]
+pub struct DataView {
+	bytes: [u8],
 }
-impl AsMut<[u8]> for DataView {
+
+impl DataView {
+	/// Returns a data view into the object's memory.
 	#[inline]
-	fn as_mut(&mut self) -> &mut [u8] {
-		&mut self.0
+	pub fn from<T: ?Sized + Pod>(v: &T) -> &DataView {
+		unsafe { mem::transmute(bytes(v)) }
+	}
+	/// Returns a mutable data view into the object's memory.
+	#[inline]
+	pub fn from_mut<T: ?Sized + Pod>(v: &mut T) -> &mut DataView {
+		unsafe { mem::transmute(bytes_mut(v)) }
 	}
 }
 
 unsafe impl Pod for DataView {}
 
+impl AsRef<[u8]> for DataView {
+	#[inline]
+	fn as_ref(&self) -> &[u8] {
+		&self.bytes
+	}
+}
+impl AsMut<[u8]> for DataView {
+	#[inline]
+	fn as_mut(&mut self) -> &mut [u8] {
+		&mut self.bytes
+	}
+}
+
 impl DataView {
 	/// Returns the number of bytes in the instance.
 	#[inline]
 	pub const fn len(&self) -> usize {
-		self.0.len()
+		self.bytes.len()
+	}
+	/// Returns the number of elements that would fit a slice starting at the given offset.
+	#[inline]
+	pub const fn tail_len<T>(&self, offset: usize) -> usize {
+		(self.bytes.len() - offset) / mem::size_of::<T>()
 	}
 }
 
 //----------------------------------------------------------------
 
+/// Reads a (potentially unaligned) value from the view.
 impl DataView {
-	/// Copies a (potentially unaligned) value from the view.
+	/// Reads a (potentially unaligned) value from the view.
 	#[inline]
-	pub fn try_copy<T: Pod>(&self, offset: usize) -> Option<T> {
+	pub fn try_read<T: Pod>(&self, offset: usize) -> Option<T> {
 		let index = offset..offset + mem::size_of::<T>();
-		let bytes = self.0.get(index)?;
+		let bytes = self.bytes.get(index)?;
 		unsafe {
 			let src = bytes.as_ptr() as *const T;
 			Some(ptr::read_unaligned(src))
 		}
 	}
-	/// Copies a (potentially unaligned) value from the view.
+	/// Reads a (potentially unaligned) value from the view.
 	#[track_caller]
 	#[inline]
-	pub fn copy<T: Pod>(&self, offset: usize) -> T {
-		match self.try_copy(offset) {
+	pub fn read<T: Pod>(&self, offset: usize) -> T {
+		match self.try_read(offset) {
 			Some(value) => value,
 			None => invalid_offset(),
 		}
 	}
-	/// Copies a (potentially unaligned) value from the view.
+	/// Reads a (potentially unaligned) value from the view.
 	#[inline]
-	pub unsafe fn copy_unchecked<T: Pod>(&self, offset: usize) -> T {
+	pub unsafe fn read_unchecked<T: Pod>(&self, offset: usize) -> T {
 		let index = offset..offset + mem::size_of::<T>();
-		let bytes = self.0.get_unchecked(index);
+		let bytes = self.bytes.get_unchecked(index);
 		let src = bytes.as_ptr() as *const T;
 		ptr::read_unaligned(src)
 	}
@@ -115,121 +135,128 @@ impl DataView {
 
 //----------------------------------------------------------------
 
+/// Reads a (potentially unaligned) value from the view into the destination.
 impl DataView {
-	/// Copies a (potentially unaligned) value from the view into the destination.
+	/// Reads a (potentially unaligned) value from the view into the destination.
 	#[inline]
-	pub fn try_copy_into<T: Pod + ?Sized>(&self, offset: usize, dest: &mut T) -> Option<()> {
+	pub fn try_read_into<T: ?Sized + Pod>(&self, offset: usize, dest: &mut T) -> Option<()> {
 		let index = offset..offset + mem::size_of_val(dest);
-		let bytes = self.0.get(index)?;
+		let bytes = self.bytes.get(index)?;
 		unsafe {
 			let src = bytes.as_ptr();
-			let dst = dest.as_bytes_mut().as_mut_ptr();
+			let dst = bytes_mut(dest).as_mut_ptr();
 			ptr::copy_nonoverlapping(src, dst, bytes.len());
 			Some(())
 		}
 	}
-	/// Copies a (potentially unaligned) value from the view into the destination.
+	/// Reads a (potentially unaligned) value from the view into the destination.
 	#[track_caller]
 	#[inline]
-	pub fn copy_into<T: Pod + ?Sized>(&self, offset: usize, dest: &mut T) {
-		match self.try_copy_into(offset, dest) {
+	pub fn read_into<T: ?Sized + Pod>(&self, offset: usize, dest: &mut T) {
+		match self.try_read_into(offset, dest) {
 			Some(()) => (),
 			None => invalid_offset(),
 		}
 	}
-	/// Copies a (potentially unaligned) value from the view into the destination.
+	/// Reads a (potentially unaligned) value from the view into the destination.
 	#[inline]
-	pub unsafe fn copy_into_unchecked<T: Pod + ?Sized>(&self, offset: usize, dest: &mut T) {
+	pub unsafe fn read_into_unchecked<T: ?Sized + Pod>(&self, offset: usize, dest: &mut T) {
 		let index = offset..offset + mem::size_of_val(dest);
-		let bytes = self.0.get_unchecked(index);
+		let bytes = self.bytes.get_unchecked(index);
 		let src = bytes.as_ptr();
-		let dst = dest.as_bytes_mut().as_mut_ptr();
+		let dst = bytes_mut(dest).as_mut_ptr();
 		ptr::copy_nonoverlapping(src, dst, bytes.len());
 	}
 }
 
 //----------------------------------------------------------------
 
+/// Gets an aligned reference into the view.
 impl DataView {
-	/// Reads an aligned value from the view.
+	/// Gets an aligned reference into the view.
 	#[inline]
-	pub fn try_read<T: Pod>(&self, offset: usize) -> Option<&T> {
+	pub fn try_get<T: Pod>(&self, offset: usize) -> Option<&T> {
 		let index = offset..offset + mem::size_of::<T>();
-		let bytes = self.0.get(index)?;
-		if bytes.as_ptr() as usize % mem::align_of::<T>() != 0 {
+		let bytes = self.bytes.get(index)?;
+		let unaligned_ptr = bytes.as_ptr() as *const T;
+		if !is_aligned(unaligned_ptr) {
 			return None;
 		}
 		unsafe {
-			Some(&*(bytes.as_ptr() as *const T))
+			Some(&*unaligned_ptr)
 		}
 	}
-	/// Reads an aligned value from the view.
+	/// Gets an aligned reference into the view.
 	#[track_caller]
 	#[inline]
-	pub fn read<T: Pod>(&self, offset: usize) -> &T {
-		match self.try_read(offset) {
+	pub fn get<T: Pod>(&self, offset: usize) -> &T {
+		match self.try_get(offset) {
 			Some(value) => value,
 			None => invalid_offset(),
 		}
 	}
-	/// Reads an aligned value from the view.
+	/// Gets an aligned reference into the view.
 	#[inline]
-	pub unsafe fn read_unchecked<T: Pod>(&self, offset: usize) -> &T {
+	pub unsafe fn get_unchecked<T: Pod>(&self, offset: usize) -> &T {
 		let index = offset..offset + mem::size_of::<T>();
-		let bytes = self.0.get_unchecked(index);
+		let bytes = self.bytes.get_unchecked(index);
 		&*(bytes.as_ptr() as *const T)
 	}
 }
 
 //----------------------------------------------------------------
 
+/// Gets an aligned mutable reference into the view.
 impl DataView {
-	/// Reads an aligned value from the view.
+	/// Gets an aligned mutable reference into the view.
 	#[inline]
-	pub fn try_read_mut<T: Pod>(&mut self, offset: usize) -> Option<&mut T> {
+	pub fn try_get_mut<T: Pod>(&mut self, offset: usize) -> Option<&mut T> {
 		let index = offset..offset + mem::size_of::<T>();
-		let bytes = self.0.get_mut(index)?;
-		if bytes.as_mut_ptr() as usize % mem::align_of::<T>() != 0 {
+		let bytes = self.bytes.get_mut(index)?;
+		let unaligned_ptr = bytes.as_mut_ptr() as *mut T;
+		if !is_aligned(unaligned_ptr) {
 			return None;
 		}
 		unsafe {
-			Some(&mut *(bytes.as_mut_ptr() as *mut T))
+			Some(&mut *unaligned_ptr)
 		}
 	}
-	/// Reads an aligned value from the view.
+	/// Gets an aligned mutable reference into the view.
 	#[track_caller]
 	#[inline]
-	pub fn read_mut<T: Pod>(&mut self, offset: usize) -> &mut T {
-		match self.try_read_mut(offset) {
+	pub fn get_mut<T: Pod>(&mut self, offset: usize) -> &mut T {
+		match self.try_get_mut(offset) {
 			Some(value) => value,
 			None => invalid_offset(),
 		}
 	}
-	/// Reads an aligned value from the view.
+	/// Gets an aligned mutable reference into the view.
 	#[inline]
-	pub unsafe fn read_unchecked_mut<T: Pod>(&mut self, offset: usize) -> &mut T {
+	pub unsafe fn get_unchecked_mut<T: Pod>(&mut self, offset: usize) -> &mut T {
 		let index = offset..offset + mem::size_of::<T>();
-		let bytes = self.0.get_unchecked_mut(index);
+		let bytes = self.bytes.get_unchecked_mut(index);
 		&mut *(bytes.as_mut_ptr() as *mut T)
 	}
 }
 
 //----------------------------------------------------------------
 
+/// Gets an aligned slice into the view.
 impl DataView {
-	/// Reads an aligned slice from the view.
+	/// Gets an aligned slice into the view.
 	#[inline]
 	pub fn try_slice<T: Pod>(&self, offset: usize, len: usize) -> Option<&[T]> {
 		let index = offset..offset + usize::checked_mul(len, mem::size_of::<T>())?;
-		let bytes = self.0.get(index)?;
-		if bytes.as_ptr() as usize % mem::align_of::<T>() != 0 {
+		let bytes = self.bytes.get(index)?;
+		let unaligned_ptr = bytes.as_ptr() as *const T;
+		if !is_aligned(unaligned_ptr) {
 			return None;
 		}
 		unsafe {
-			Some(slice::from_raw_parts(bytes.as_ptr() as *const T, len))
+			Some(slice::from_raw_parts(unaligned_ptr, len))
 		}
 	}
-	/// Reads an aligned slice from the view.
+	/// Gets an aligned slice into the view.
 	#[track_caller]
 	#[inline]
 	pub fn slice<T: Pod>(&self, offset: usize, len: usize) -> &[T] {
@@ -238,31 +265,33 @@ impl DataView {
 			None => invalid_offset(),
 		}
 	}
-	/// Reads an aligned slice from the view.
+	/// Gets an aligned slice into the view.
 	#[inline]
 	pub unsafe fn slice_unchecked<T: Pod>(&self, offset: usize, len: usize) -> &[T] {
-		let index = offset..offset + usize::wrapping_mul(len, mem::size_of::<T>());
-		let bytes = self.0.get_unchecked(index);
+		let index = offset..offset + len * mem::size_of::<T>();
+		let bytes = self.bytes.get_unchecked(index);
 		slice::from_raw_parts(bytes.as_ptr() as *const T, len)
 	}
 }
 
 //----------------------------------------------------------------
 
+/// Gets an aligned mutable slice into the view.
 impl DataView {
-	/// Reads an aligned slice from the view.
+	/// Gets an aligned mutable slice into the view.
 	#[inline]
 	pub fn try_slice_mut<T: Pod>(&mut self, offset: usize, len: usize) -> Option<&mut [T]> {
 		let index = offset..offset + usize::checked_mul(len, mem::size_of::<T>())?;
-		let bytes = self.0.get_mut(index)?;
-		if bytes.as_mut_ptr() as usize % mem::align_of::<T>() != 0 {
+		let bytes = self.bytes.get_mut(index)?;
+		let unaligned_ptr = bytes.as_mut_ptr() as *mut T;
+		if !is_aligned(unaligned_ptr) {
 			return None;
 		}
 		unsafe {
-			Some(slice::from_raw_parts_mut(bytes.as_mut_ptr() as *mut T, len))
+			Some(slice::from_raw_parts_mut(unaligned_ptr, len))
 		}
 	}
-	/// Reads an aligned slice from the view.
+	/// Gets an aligned mutable slice into the view.
 	#[track_caller]
 	#[inline]
 	pub fn slice_mut<T: Pod>(&mut self, offset: usize, len: usize) -> &mut [T] {
@@ -271,51 +300,42 @@ impl DataView {
 			None => invalid_offset(),
 		}
 	}
-	/// Reads an aligned slice from the view.
+	/// Gets an aligned mutable slice into the view.
 	#[inline]
 	pub unsafe fn slice_unchecked_mut<T: Pod>(&mut self, offset: usize, len: usize) -> &mut [T] {
-		let index = offset..offset + usize::wrapping_mul(len, mem::size_of::<T>());
-		let bytes = self.0.get_unchecked_mut(index);
+		let index = offset..offset + len * mem::size_of::<T>();
+		let bytes = self.bytes.get_unchecked_mut(index);
 		slice::from_raw_parts_mut(bytes.as_mut_ptr() as *mut T, len)
 	}
 }
 
 //----------------------------------------------------------------
 
+/// Writes a value into the view.
 impl DataView {
-	/// Returns the number of elements that would fit a slice starting at the given offset.
+	/// Writes a value into the view.
 	#[inline]
-	pub const fn tail_len<T>(&self, offset: usize) -> usize {
-		(self.0.len() - offset) / mem::size_of::<T>()
-	}
-}
-
-//----------------------------------------------------------------
-
-impl DataView {
-	/// Writes a value to the view.
-	#[inline]
-	pub fn try_write<T: Pod + ?Sized>(&mut self, offset: usize, value: &T) -> Option<()> {
+	pub fn try_write<T: ?Sized + Pod>(&mut self, offset: usize, value: &T) -> Option<()> {
 		let index = offset..offset + mem::size_of_val(value);
-		let bytes = self.0.get_mut(index)?;
-		bytes.copy_from_slice(value.as_bytes());
+		let bytes = self.bytes.get_mut(index)?;
+		bytes.copy_from_slice(crate::bytes(value));
 		Some(())
 	}
-	/// Writes a value to the view.
+	/// Writes a value into the view.
 	#[track_caller]
 	#[inline]
-	pub fn write<T: Pod + ?Sized>(&mut self, offset: usize, value: &T) {
+	pub fn write<T: ?Sized + Pod>(&mut self, offset: usize, value: &T) {
 		match self.try_write(offset, value) {
 			Some(()) => (),
 			None => invalid_offset(),
 		}
 	}
-	/// Writes a value to the view.
+	/// Writes a value into the view.
 	#[inline]
-	pub unsafe fn write_unchecked<T: Pod + ?Sized>(&mut self, offset: usize, value: &T) {
+	pub unsafe fn write_unchecked<T: ?Sized + Pod>(&mut self, offset: usize, value: &T) {
 		let index = offset..offset + mem::size_of_val(value);
-		let bytes = self.0.get_unchecked_mut(index);
-		ptr::copy_nonoverlapping(value.as_bytes().as_ptr(), bytes.as_mut_ptr(), bytes.len());
+		let bytes = self.bytes.get_unchecked_mut(index);
+		ptr::copy_nonoverlapping(crate::bytes(value).as_ptr(), bytes.as_mut_ptr(), bytes.len());
 	}
 }
 
@@ -327,32 +347,32 @@ impl DataView {
 	pub fn index<R: ops::RangeBounds<usize>>(&self, range: R) -> Option<&DataView> {
 		let start = match range.start_bound() {
 			ops::Bound::Unbounded => 0,
-			ops::Bound::Included(start) => *start,
-			ops::Bound::Excluded(start) => *start + 1,
+			ops::Bound::Included(&start) => start,
+			ops::Bound::Excluded(&start) => start + 1,
 		};
 		let end = match range.end_bound() {
 			ops::Bound::Unbounded => self.len(),
-			ops::Bound::Included(end) => *end + 1,
-			ops::Bound::Excluded(end) => *end,
+			ops::Bound::Included(&end) => end + 1,
+			ops::Bound::Excluded(&end) => end,
 		};
-		let bytes = self.0.get(start..end)?;
-		Some(bytes.as_data_view())
+		let bytes = self.bytes.get(start..end)?;
+		Some(DataView::from(bytes))
 	}
 	/// Index the DataView creating a mutable subview.
 	#[inline]
 	pub fn index_mut<R: ops::RangeBounds<usize>>(&mut self, range: R) -> Option<&mut DataView> {
 		let start = match range.start_bound() {
 			ops::Bound::Unbounded => 0,
-			ops::Bound::Included(start) => *start,
-			ops::Bound::Excluded(start) => *start + 1,
+			ops::Bound::Included(&start) => start,
+			ops::Bound::Excluded(&start) => start + 1,
 		};
 		let end = match range.end_bound() {
 			ops::Bound::Unbounded => self.len(),
-			ops::Bound::Included(end) => *end + 1,
-			ops::Bound::Excluded(end) => *end,
+			ops::Bound::Included(&end) => end + 1,
+			ops::Bound::Excluded(&end) => end,
 		};
-		let bytes = self.0.get_mut(start..end)?;
-		Some(bytes.as_data_view_mut())
+		let bytes = self.bytes.get_mut(start..end)?;
+		Some(DataView::from_mut(bytes))
 	}
 }
 
@@ -360,7 +380,7 @@ impl DataView {
 
 impl<R: ops::RangeBounds<usize>> ops::Index<R> for DataView {
 	type Output = DataView;
-
+	#[track_caller]
 	#[inline]
 	fn index(&self, range: R) -> &DataView {
 		match self.index(range) {
@@ -370,57 +390,13 @@ impl<R: ops::RangeBounds<usize>> ops::Index<R> for DataView {
 	}
 }
 impl<R: ops::RangeBounds<usize>> ops::IndexMut<R> for DataView {
+	#[track_caller]
 	#[inline]
 	fn index_mut(&mut self, range: R) -> &mut DataView {
 		match self.index_mut(range) {
 			Some(value) => value,
 			None => invalid_offset(),
 		}
-	}
-}
-
-//----------------------------------------------------------------
-
-#[doc(hidden)]
-impl DataView {
-	/// Reads the largest slice from the view.
-	#[inline]
-	pub fn try_slice_tail<T: Pod>(&self, offset: usize) -> Option<&[T]> {
-		self.try_slice(offset, self.tail_len::<T>(offset))
-	}
-	/// Reads the largest slice from the view.
-	#[track_caller]
-	#[inline]
-	pub fn slice_tail<T: Pod>(&self, offset: usize) -> &[T] {
-		match self.try_slice_tail(offset) {
-			Some(value) => value,
-			None => invalid_offset(),
-		}
-	}
-	/// Reads the largest slice from the view.
-	#[inline]
-	pub unsafe fn slice_tail_unchecked<T: Pod>(&self, offset: usize) -> &[T] {
-		self.slice_unchecked(offset, self.tail_len::<T>(offset))
-	}
-
-	/// Reads the largest slice from the view.
-	#[inline]
-	pub fn try_slice_tail_mut<T: Pod>(&mut self, offset: usize) -> Option<&mut [T]> {
-		self.try_slice_mut(offset, self.tail_len::<T>(offset))
-	}
-	/// Reads the largest slice from the view.
-	#[track_caller]
-	#[inline]
-	pub fn slice_tail_mut<T: Pod>(&mut self, offset: usize) -> &mut [T] {
-		match self.try_slice_tail_mut(offset) {
-			Some(value) => value,
-			None => invalid_offset(),
-		}
-	}
-	/// Reads the largest slice from the view.
-	#[inline]
-	pub unsafe fn slice_tail_unchecked_mut<T: Pod>(&mut self, offset: usize) -> &mut [T] {
-		self.slice_unchecked_mut(offset, self.tail_len::<T>(offset))
 	}
 }
 

--- a/src/field_offsets.rs
+++ b/src/field_offsets.rs
@@ -1,0 +1,50 @@
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __field_offsets {
+	(
+		$(#$meta:tt)*
+		$vis:vis struct $name:ident {
+			$(
+				$(#[$field_meta:meta])*
+				$field_vis:vis $field_name:ident: $field_ty:ty
+			),*
+			$(,)?
+		}
+	) => {
+		const _: () = {
+			#[derive(Copy, Clone, Debug)]
+			$vis struct FieldOffsets {
+				$($field_vis $field_name: usize,)*
+			}
+			impl $name where Self: $crate::Pod {
+				const FIELD_OFFSETS: FieldOffsets = $crate::__field_offsets_impl!(0usize; {} $($field_name: $field_ty,)*);
+			}
+		};
+	};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __field_offsets_impl {
+	(
+		$offset:expr;
+		{$($init_name:ident: $init_expr:expr,)*}
+		$field_name:ident: $field_ty:ty,
+		$($tail_name:ident: $tail_ty:ty,)*
+	) => {
+		$crate::__field_offsets_impl!(
+			$offset + ::core::mem::size_of::<$field_ty>();
+			{ $($init_name: $init_expr,)* $field_name: $offset, }
+			$($tail_name: $tail_ty,)*
+		)
+	};
+	(
+		$offset:expr;
+		{$($init_name:ident: $init_expr:expr,)*}
+	) => {
+		FieldOffsets {
+			$($init_name: $init_expr,)*
+		}
+	};
+}

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -1,0 +1,151 @@
+
+/// Returns the offset of a field.
+///
+/// ```
+/// #[repr(C)]
+/// struct Data {
+/// 	byte: u8,
+/// 	float: f32,
+/// }
+///
+/// let offset = dataview::offset_of!(Data.float);
+/// assert_eq!(offset, 4);
+/// ```
+///
+/// The syntax is `$ty.$field`.
+///
+/// No support for tuples, tuple structs or unions.
+///
+/// No support for projecting through multiple fields.
+#[macro_export]
+macro_rules! offset_of {
+	($($tt:tt)*) => {
+		$crate::__offset_of!([] $($tt)*)
+	};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __offset_of {
+	([$($ty:tt)*] . $($field:ident)?) => {{
+		type Ty = $($ty)*;
+		// Assert that field exists on the type
+		// This prevents auto-Deref from causing UB
+		let Ty { $($field)?: _, .. };
+		// Use MaybeUninit as the subject of the field offset
+		let mut uninit = ::core::mem::MaybeUninit::<Ty>::uninit();
+		let uninit_ptr = uninit.as_mut_ptr();
+		// We've asserted that the field exists on the type
+		// No Deref coercion or dereferencing a reference
+		// Hope that's enough to keep the code safe
+		#[allow(unused_unsafe)]
+		unsafe {
+			let field_ptr = ::core::ptr::addr_of_mut!((*uninit_ptr).$($field)?);
+			(field_ptr as *mut u8).offset_from(uninit_ptr as *mut u8) as usize
+		}
+	}};
+	([$($ty:tt)*] . $($field:tt)?) => {
+		compile_error!("offset of tuple field not supported")
+	};
+	([$($ty:tt)*] $tt:tt $($tail:tt)*) => {
+		$crate::__offset_of!([$($ty)* $tt] $($tail)*)
+	};
+	([$($ty:tt)*]) => {
+		compile_error!("missing field access")
+	};
+}
+
+/// Returns the `start..end` offsets of a field.
+///
+/// ```
+/// #[repr(C)]
+/// struct Data {
+/// 	byte: u8,
+/// 	float: f32,
+/// }
+///
+/// let span = dataview::span_of!(Data.float);
+/// assert_eq!(span, 4..8);
+/// assert_eq!(span.len(), 4);
+/// ```
+///
+/// The syntax is `$ty.$field`.
+///
+/// No support for tuples, tuple structs or unions.
+///
+/// No support for projecting through multiple fields.
+#[macro_export]
+macro_rules! span_of {
+	($($tt:tt)*) => {
+		$crate::__span_of!([] $($tt)*)
+	};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __span_of {
+	([$($ty:tt)*] . $($field:ident)?) => {{
+		type Ty = $($ty)*;
+		// Assert that field exists on the type
+		// This prevents auto-Deref from causing UB
+		let Ty { $($field)?: _, .. };
+		// Use MaybeUninit as the subject of the field offset
+		let mut uninit = ::core::mem::MaybeUninit::<Ty>::uninit();
+		let uninit_ptr = uninit.as_mut_ptr();
+		// We've asserted that the field exists on the type
+		// No Deref coercion or dereferencing a reference
+		// Hope that's enough to keep the code safe
+		#[allow(unused_unsafe)]
+		unsafe {
+			let field_ptr = ::core::ptr::addr_of_mut!((*uninit_ptr).$($field)?);
+			let start = (field_ptr as *mut u8).offset_from(uninit_ptr as *mut u8) as usize;
+			let end = (field_ptr.offset(1) as *mut u8).offset_from(uninit_ptr as *mut u8) as usize;
+			start..end
+		}
+	}};
+	([$($ty:tt)*] . $($field:tt)?) => {
+		compile_error!("offset of tuple field not supported")
+	};
+	([$($ty:tt)*] $tt:tt $($tail:tt)*) => {
+		$crate::__span_of!([$($ty)* $tt] $($tail)*)
+	};
+	([$($ty:tt)*]) => {
+		compile_error!("missing field access")
+	};
+}
+
+#[test]
+fn nested_fields() {
+	#[repr(C)]
+	struct Foo<T> { byte: u8, value: T }
+
+	assert_eq!(offset_of!(Foo<i32>.value), 4);
+	assert_eq!(span_of!(Foo<i32>.value), 4..8);
+}
+
+#[cfg(doc)]
+/**
+```compile_fail
+use std::ops;
+struct Target {
+	target: f32,
+}
+struct Subject {
+	field: i32,
+	deref: Target,
+}
+impl ops::Deref for Subject {
+	type Target = Target;
+	fn deref(&self) -> &Target {
+		&self.deref
+	}
+}
+impl ops::DerefMut for Subject {
+	fn deref_mut(&mut self) -> &mut Target {
+		&mut self.deref
+	}
+}
+let _ = dataview::offset_of!(Subject.target);
+```
+*/
+fn deref_protection() {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,22 +10,10 @@ struct Baz([u32; 2]);
 unsafe impl Pod for Baz {}
 
 #[test]
-fn test_transmute() {
-	let data = [42, 13];
-	let mut a = Foo(data);
-	let b: Baz = a.transmute();
-	assert_eq!(data, b.0);
-	let c: &Baz = a.transmute_ref();
-	assert_eq!(data, c.0);
-	let d: &mut Baz = a.transmute_mut();
-	assert_eq!(data, d.0);
-}
-
-#[test]
 fn test_zeroed() {
-	let a = Foo::zeroed();
+	let a: Foo = zeroed();
 	assert_eq!([0u32; 2], a.0);
-	let b = <[f32; 2]>::zeroed();
+	let b: [f32; 2] = zeroed();
 	assert_eq!([0f32; 2], b);
 }
 
@@ -38,87 +26,87 @@ static TEST_DATA: ([u64; 0], [u8; 8]) = ([], [0, 1, 2, 3, 4, 5, 6, 7]);
 #[test]
 fn test_basics() {
 	let bytes = &TEST_DATA.1;
-	let view = bytes.as_data_view();
+	let view = DataView::from(bytes);
 	assert_eq!(view.len(), bytes.len());
 	assert_eq!(view.as_ref(), bytes);
 }
 
 #[test]
-fn test_copy() {
-	let bytes = &TEST_DATA.1;
-	let view = bytes.as_data_view();
-	for i in 0..bytes.len() {
-		let value = i as u8;
-		assert_eq!(value, bytes[i]);
-		assert_eq!(Some(value), view.try_copy(i));
-		assert_eq!(value, view.copy(i));
-		assert_eq!(value, unsafe { view.copy_unchecked(i) });
-	}
-	assert!(matches!(view.try_copy::<u8>(view.len()), None));
-}
-
-#[test]
-fn test_copy_into() {
-	let bytes = &TEST_DATA.1;
-	let view = bytes.as_data_view();
-	let mut dest: u8;
-	for i in 0..bytes.len() {
-		let value = i as u8;
-		assert_eq!(value, bytes[i]);
-		dest = !0;
-		assert_eq!(Some(()), view.try_copy_into(i, &mut dest));
-		assert_eq!(value, dest);
-		dest = !0;
-		view.copy_into(i, &mut dest);
-		assert_eq!(value, dest);
-		dest = !0;
-		unsafe { view.copy_into_unchecked(i, &mut dest); }
-		assert_eq!(value, dest);
-	}
-	dest = !0;
-	assert!(matches!(view.try_copy_into::<u8>(view.len(), &mut dest), None));
-}
-
-#[test]
 fn test_read() {
 	let bytes = &TEST_DATA.1;
-	let view = bytes.as_data_view();
+	let view = DataView::from(bytes);
 	for i in 0..bytes.len() {
 		let value = i as u8;
 		assert_eq!(value, bytes[i]);
-		assert_eq!(Some(&value), view.try_read(i));
-		assert_eq!(&value, view.read(i));
-		assert_eq!(&value, unsafe { view.read_unchecked(i) });
-		if i % 2 == 1 {
-			assert!(matches!(view.try_read::<u16>(i), None));
-		}
+		assert_eq!(Some(value), view.try_read(i));
+		assert_eq!(value, view.read(i));
+		assert_eq!(value, unsafe { view.read_unchecked(i) });
 	}
 	assert!(matches!(view.try_read::<u8>(view.len()), None));
 }
 
 #[test]
-fn test_read_mut() {
+fn test_read_into() {
+	let bytes = &TEST_DATA.1;
+	let view = DataView::from(bytes);
+	let mut dest: u8;
+	for i in 0..bytes.len() {
+		let value = i as u8;
+		assert_eq!(value, bytes[i]);
+		dest = !0;
+		assert_eq!(Some(()), view.try_read_into(i, &mut dest));
+		assert_eq!(value, dest);
+		dest = !0;
+		view.read_into(i, &mut dest);
+		assert_eq!(value, dest);
+		dest = !0;
+		unsafe { view.read_into_unchecked(i, &mut dest); }
+		assert_eq!(value, dest);
+	}
+	dest = !0;
+	assert!(matches!(view.try_read_into::<u8>(view.len(), &mut dest), None));
+}
+
+#[test]
+fn test_get() {
+	let bytes = &TEST_DATA.1;
+	let view = DataView::from(bytes);
+	for i in 0..bytes.len() {
+		let value = i as u8;
+		assert_eq!(value, bytes[i]);
+		assert_eq!(Some(&value), view.try_get(i));
+		assert_eq!(&value, view.get(i));
+		assert_eq!(&value, unsafe { view.get_unchecked(i) });
+		if i % 2 == 1 {
+			assert!(matches!(view.try_get::<u16>(i), None));
+		}
+	}
+	assert!(matches!(view.try_get::<u8>(view.len()), None));
+}
+
+#[test]
+fn test_get_mut() {
 	let mut data = TEST_DATA;
 	let check = TEST_DATA.1;
 	let bytes = &mut data.1;
-	let view = bytes.as_data_view_mut();
+	let view = DataView::from_mut(bytes);
 	for i in 0..check.len() {
 		let mut value = i as u8;
 		assert_eq!(value, check[i]);
-		assert_eq!(Some(&mut value), view.try_read_mut(i));
-		assert_eq!(&value, view.read_mut(i));
-		assert_eq!(&value, unsafe { view.read_unchecked_mut(i) });
+		assert_eq!(Some(&mut value), view.try_get_mut(i));
+		assert_eq!(&value, view.get_mut(i));
+		assert_eq!(&value, unsafe { view.get_unchecked_mut(i) });
 		if i % 2 == 1 {
-			assert!(matches!(view.try_read_mut::<u16>(i), None));
+			assert!(matches!(view.try_get_mut::<u16>(i), None));
 		}
 	}
-	assert!(matches!(view.try_read_mut::<u8>(view.len()), None));
+	assert!(matches!(view.try_get_mut::<u8>(view.len()), None));
 }
 
 #[test]
 fn test_slice() {
 	let bytes = &TEST_DATA.1;
-	let view = bytes.as_data_view();
+	let view = DataView::from(bytes);
 	for i in 0..=bytes.len() {
 		for j in i..=bytes.len() {
 			let value = &bytes[i..j];
@@ -139,7 +127,7 @@ fn test_slice_mut() {
 	let mut data = TEST_DATA;
 	let mut check = TEST_DATA.1;
 	let bytes = &mut data.1;
-	let view = bytes.as_data_view_mut();
+	let view = DataView::from_mut(bytes);
 	for i in 0..=check.len() {
 		for j in i..=check.len() {
 			let value = &mut check[i..j];

--- a/tests/derive_pod.rs
+++ b/tests/derive_pod.rs
@@ -1,6 +1,10 @@
 #![allow(dead_code)]
 
-use dataview::Pod;
+use dataview::{Pod, FieldOffsets};
+
+#[derive(Pod)]
+#[repr(C)]
+struct Struct0 {}
 
 #[derive(Pod)]
 #[repr(C)]
@@ -36,6 +40,27 @@ struct Struct4 {
 }
 
 #[derive(Pod)]
+#[repr(align(8), C)]
+struct Struct5 {
+	field1: i32,
+	field2: f32
+}
+
+#[derive(Pod, FieldOffsets)]
+#[repr(C, align(8))]
+struct Struct6 {
+	field1: i32,
+	field2: f32
+}
+
+const _: [(); 0] = [(); Struct6::FIELD_OFFSETS.field1];
+const _: [(); 4] = [(); Struct6::FIELD_OFFSETS.field2];
+
+#[derive(Pod)]
+#[repr(C)]
+struct Tuple0();
+
+#[derive(Pod)]
 #[repr(C)]
 struct Tuple1(i32);
 
@@ -50,3 +75,7 @@ struct Tuple3(i32, f32);
 #[derive(Pod)]
 #[repr(C)]
 struct Tuple4(i32, f32,);
+
+#[derive(Pod)]
+#[repr(C)]
+struct Unit;


### PR DESCRIPTION
**This is a hard breaking change!**

Making Pod a marker trait and providing its methods as crate functions enables the rust semver trick.
This trick is impossible to execute in the current state and prevents any kind of change in design of this crate.
Bikeshedding the helper method names is now possible without further breaking changes!

At the same time I feel confident enough to embark on a 1.0.0 journey with the ability to improve the API if needed.